### PR TITLE
fix bug where lockfile integrity would be reset when running tree() as the manifest was not gotten, also add a charset arg to tree()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-package-manager"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 authors = ["bendn <bend.n@outlook.com>"]
 description = "A package manager for godot"


### PR DESCRIPTION
also removes the unused `PackageLock` struct in `config_file.rs`