### PR TITLE
add more options to tree(): `--prefix` and `--tarballs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-package-manager"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["bendn <bend.n@outlook.com>"]
 description = "A package manager for godot"


### PR DESCRIPTION
as requested by navi,

```bash
$ gpm tree --tarballs --prefix none
@bendn/test@2.0.10 https://registry.npmjs.org/@bendn/test/-/test-2.0.10.tgz
@bendn/gdcli@1.2.5 https://registry.npmjs.org/@bendn/gdcli/-/gdcli-1.2.5.tgz
```