### PR TITLE
cargo like cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-package-manager"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["bendn <bend.n@outlook.com>"]
 description = "A package manager for godot"

--- a/src/package.rs
+++ b/src/package.rs
@@ -217,7 +217,7 @@ impl Package {
     }
 
     /// Returns the download directory for this package depending on wether it is indirect or not.
-    fn download_dir(&self) -> String {
+    pub fn download_dir(&self) -> String {
         if self.indirect {
             self.indirect_download_dir()
         } else {
@@ -338,7 +338,7 @@ impl Package {
             }
         };
         eprintln!(
-            "{}: Could not find path for {path:#?}",
+            "{:>12} Could not find path for {path:#?}",
             crate::print_consts::warn()
         );
         return path.to_path_buf();


### PR DESCRIPTION
finalizes #18

output:
```
 cargo run -- -u
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/godot-package-manager -u`
  Downloaded @bendn/test@2.0.10
  Downloaded @bendn/gdcli@1.2.5
    Finished updated 2 packages in 8 seconds
```

also adds a progress bar to purge (idk why unless you have a super slow windows filesystem youll never see it)