### PR TITLE
fix bug where `preload("./thing")` would become `preload("res://./thing")`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-package-manager"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["bendn <bend.n@outlook.com>"]
 description = "A package manager for godot"


### PR DESCRIPTION
probably should add tests for this or something

also accidentally made #22